### PR TITLE
Document mkdocs command in python virtual env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# NearNodeFlash Pages
+
+# Create mkdocs Environment
+
+```bash
+$ git@github.com:NearNodeFlash/NearNodeFlash.github.io.git
+$ cd NearNodeFlash.github.io.git
+$ python3 -m venv venv
+$ . venv/bin/activate
+(venv) $ pip install -r requirements.txt
+```
+
+# Run mkdocs Server
+
+```bash
+(venv) $ mkdocs serve
+INFO     -  Building documentation...
+[...]
+INFO     -  Documentation built in 0.22 seconds
+INFO     -  [10:59:28] Watching paths for changes: 'docs', 'mkdocs.yml'
+INFO     -  [10:59:28] Serving on http://127.0.0.1:8000/
+```
+
+Now point your browser at http://127.0.0.1:8000/
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+mkdocs
 mkdocs-section-index
 mkdocs-macros-plugin
+mkdocs-material
+mkdocs-material-extensions
+


### PR DESCRIPTION
Update the requirements.txt to pull in the mkdocs command and its dependencies.

Add a readme to explain how to use a python virtualenv to run mkdocs.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>