### PR TITLE
Update the bash script that retrieves token & cert to support Kuberne…

### DIFF
--- a/docs/guides/compute-daemons/readme.md
+++ b/docs/guides/compute-daemons/readme.md
@@ -39,9 +39,8 @@ NNF software defines a Kubernetes Service Account for granting communication pri
 SERVICE_ACCOUNT=$1
 NAMESPACE=$2
 
-SECRET=$(kubectl get serviceaccount ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o json | jq -Mr '.secrets[].name | select(contains("token"))')
-kubectl get secret ${SECRET} -n ${NAMESPACE} -o json | jq -Mr '.data.token' | base64 -D > ./service.token
-kubectl get secret ${SECRET} -n ${NAMESPACE} -o json | jq -Mr '.data["ca.crt"]' | base64 -D > ./service.cert
+kubectl get secret ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o json | jq -Mr '.data.token' | base64 -D > ./service.token
+kubectl get secret ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o json | jq -Mr '.data["ca.crt"]' | base64 -D > ./service.cert
 ```
 
 The `service.token` and `service.cert` files must be copied to each compute node, typically in the `/etc/[BINARY-NAME]/` directory


### PR DESCRIPTION
Update the bash script that retrieves token & cert to support Kuberne 1.25+

The script is backward compatible - I verified it works on our htx system

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>