### PR TITLE
Document the default '--node-name' and '--nnf-node-name' behavior

### DIFF
--- a/docs/guides/compute-daemons/readme.md
+++ b/docs/guides/compute-daemons/readme.md
@@ -57,7 +57,7 @@ The command line arguements can be provided to the service definition or as an o
 | `--kubernetes-service-port=[PORT]` | The listening port of the kubeapi server |
 | `--service-token-file=[PATH]` | Location of the service token file |
 | `--service-cert-file=[PATH]` | Location of the service certificate file |
-| `--node-name=[COMPUTE-NODE-NAME]` | Name of this compute node as described in the System Configuration. Defaults to the os.Hostname() value. |
+| `--node-name=[COMPUTE-NODE-NAME]` | Name of this compute node as described in the System Configuration. Defaults to the host name reported by the OS. |
 | `--nnf-node-name=[RABBIT-NODE-NAME]` | `nnf-dm` daemon only. Name of the rabbit node connected to this compute node as described in the System Configuration. If not provided, the `--node-name` value is used to find the associated Rabbit node in the System Configuration. |
 | `--sys-config=[NAME]` | `nnf-dm` daemon only. The System Configuration resource's name. Defaults to `default` |
 

--- a/docs/guides/compute-daemons/readme.md
+++ b/docs/guides/compute-daemons/readme.md
@@ -57,8 +57,9 @@ The command line arguements can be provided to the service definition or as an o
 | `--kubernetes-service-port=[PORT]` | The listening port of the kubeapi server |
 | `--service-token-file=[PATH]` | Location of the service token file |
 | `--service-cert-file=[PATH]` | Location of the service certificate file |
-| `--node-name=[COMPUTE-NODE-NAME]` | Name of this compute node as described in the System Configuration |
-| `--nnf-node-name=[RABBIT-NODE-NAME]` | Name of the rabbit node connected to this compute node as described in the System Configuration (`nnf-dm` daemon only)|
+| `--node-name=[COMPUTE-NODE-NAME]` | Name of this compute node as described in the System Configuration. Defaults to the os.Hostname() value. |
+| `--nnf-node-name=[RABBIT-NODE-NAME]` | `nnf-dm` daemon only. Name of the rabbit node connected to this compute node as described in the System Configuration. If not provided, the `--node-name` value is used to find the associated Rabbit node in the System Configuration. |
+| `--sys-config=[NAME]` | `nnf-dm` daemon only. The System Configuration resource's name. Defaults to `default` |
 
 For example:
 


### PR DESCRIPTION
Describes the new default behavior added to the [clientmount](https://github.com/HewlettPackard/dws/pull/74) and [nnf-dm](https://github.com/NearNodeFlash/nnf-dm/pull/76) daemons with regards to the `--node-name` and `--nnf-node-name` values.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>