### PR TITLE
Shell script to grab the token and cert must use the longform base64 …

### DIFF
--- a/docs/guides/compute-daemons/readme.md
+++ b/docs/guides/compute-daemons/readme.md
@@ -39,8 +39,8 @@ NNF software defines a Kubernetes Service Account for granting communication pri
 SERVICE_ACCOUNT=$1
 NAMESPACE=$2
 
-kubectl get secret ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o json | jq -Mr '.data.token' | base64 -D > ./service.token
-kubectl get secret ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o json | jq -Mr '.data["ca.crt"]' | base64 -D > ./service.cert
+kubectl get secret ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o json | jq -Mr '.data.token' | base64 --decode > ./service.token
+kubectl get secret ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o json | jq -Mr '.data["ca.crt"]' | base64 -decode > ./service.cert
 ```
 
 The `service.token` and `service.cert` files must be copied to each compute node, typically in the `/etc/[BINARY-NAME]/` directory


### PR DESCRIPTION
Shell script to grab the token and cert must use the longform base64 `--decode` option for Linux. The `-D` option is only valid on mac platforms. `--decode` is valid on both.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>