### PR TITLE
Rounded out User Container guide

### DIFF
--- a/docs/guides/user-containers/readme.md
+++ b/docs/guides/user-containers/readme.md
@@ -1,96 +1,181 @@
 # NNF User Containers
 
-NNF User Containers are a mechanism to allow user-defined containerized
-applications to be run on Rabbit nodes with access to NNF ephemeral and persistent storage.
+NNF User Containers are a mechanism to allow user-defined containerized applications to be run on
+Rabbit nodes with access to NNF ephemeral and persistent storage.
 
-!!! note
+## Overview
 
-    The following is a limited look at User Containers.  More content will be
-    provided after the RFC has been finalized. This is a work in progress.
+Container workflows are orchestrated through the use of two components: Container Profiles and
+Container Directives. A Container Profile defines the container to be executed. Most
+importantly, it allows you to specify which NNF storages are accessible within the container and
+which container image to run. The containers are executed on the NNF nodes that are allocated to
+your container workflow. These containers can be executed in either of two modes: Non-MPI and MPI.
 
-## Environment Variables
+For Non-MPI applications, the image and command are launched across all the the targeted NNF Nodes
+in a uniform manner. This is useful in simple applications, where non-distributed behavior is
+desired.
 
-Two sets of environment variables are available with container workflows: Container and Compute Node. The former are the variables that are available inside the user containers. The latter are the variables that are provided back to the DWS workflow, which in turn are collected by the WLM and provided to compute nodes. See the WLM documentation for more details.
+For MPI applications, a single launcher container serves as the point of contact, responsible for
+distributing tasks to various worker containers. Each of the NNF nodes targeted by the workflow
+receives its corresponding worker container. The focus of this documentation will be on MPI
+applications.
 
-### Container Environment Variables
+To see a full working example before diving into these docs, see [this](#putting-it-all-together).
 
-These variables are provided for use inside the container. They can be used as part of the
-container command in the NNF Container Profile or within the container itself.
+## Before Creating a Container Workflow
 
-#### Container Hostnames and Domains
+Before creating a workflow, a working `NnfContainerProfile` must exist. This profile is referenced
+in the container directive supplied with the workflow.
 
-Containers can contact one another via Kubernetes cluster networking. This functionality is provided by DNS. Environment variables are provided that allow a user to be able to piece together the FQDN so that the other containers can be contacted.
+### Container Profiles
 
-This example demonstrates an MPI container workflow, with two worker pods. Two worker pods means two pods/containers running on two NNF nodes.
+The author of a containerized application will work with the administrator to define a pod
+specification template for the container and to create an appropriate `NnfContainerProfile` resource
+for the container. The image and tag for the user's container will be specified in the profile.
 
-```console
-mpiuser@my-container-workflow-launcher:~$ env | grep NNF
-NNF_CONTAINER_HOSTNAMES=my-container-workflow-launcher my-container-workflow-worker-0 my-container-workflow-worker-1
-NNF_CONTAINER_DOMAIN=default.svc.cluster.local
-NNF_CONTAINER_SUBDOMAIN=my-container-workflow-worker
-```
+The image must be available in a registry that is available to your system. This could be docker.io,
+ghcr.io, etc., or a private registry. Note that for a private registry, some additional setup is
+required. See [here](#using-a-private-container-repository) for more info.
 
-The container FQDN consists of the following: `<HOSTNAME>.<SUBDOMAIN>.<DOMAIN>`. To contact the other worker container from worker 0, `my-container-workflow-worker-1.my-container-workflow-worker.default.svc.cluster.local` would be used.
+The image itself has a few requirements. See [here](#creating-images) for more info on building images.
 
-For MPI-based containers, an alternate way to retrieve this information is to look at the default `hostfile`, provided by `mpi-operator`. This file lists out all the worker nodes' FQDNs:
-
-```console
-mpiuser@my-container-workflow-launcher:~$ cat /etc/mpi/hostfile
-my-container-workflow-worker-0.my-container-workflow-worker.default.svc slots=1
-my-container-workflow-worker-1.my-container-workflow-worker.default.svc slots=1
-```
-
-### Compute Node Environment Variables
-
-These environment variables are provided to the compute node via the WLM by way of the DWS Workflow. Note that these environment variables are consistent across all the compute nodes for a given workflow.
-
-#### `NNF_CONTAINER_PORTS`
-
-If the NNF Container Profile requests container ports, then this environment variable provides the allocated ports for the container. This is a comma separated list of ports if multiple ports are requested.
-
-This allows an application on the compute node to contact the user container running on its local NNF node via these port numbers. The compute node must have proper routing to the NNF Node and needs a generic way of contacting the NNF node. It is suggested than a DNS entry is provided via `/etc/hosts`, or similar.
-
-For cases where one port is requested, the following can be used to contact the user container running on the NNF node (assuming an entry for `local-rabbit` is provided via `/etc/hosts`).
+New `NnfContainerProfile` resources may be created by copying one of the provided example profiles
+from the `nnf-system` namespace . The examples may be found by listing them with `kubectl`:
 
 ```console
-local-rabbit:$(NNF_CONTAINER_PORTS)
+kubectl get nnfcontainerprofiles -n nnf-system
 ```
 
-## Container Ports
+The next few subsections provide an overview of the primary components comprising an
+`NnfContainerProfile`. However, it's important to note that while these sections cover the key
+aspects, they don't encompass every single detail. For an in-depth understanding of the capabilities
+offered by container profiles, we recommend referring to the following resources:
 
-NNF Container Profiles allow for ports to be reserved for a container workflow. `numPorts` can be used to specify the number of ports needed for a container workflow:
+- [Type definition](https://github.com/NearNodeFlash/nnf-sos/blob/master/api/v1alpha1/nnfcontainerprofile_types.go#L35) for `NnfContainerProfile`
+- [Sample](https://github.com/NearNodeFlash/nnf-sos/blob/master/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml) for `NnfContainerProfile`
+- [Online Examples](https://github.com/NearNodeFlash/nnf-sos/blob/master/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml) for `NnfContainerProfile` (same as `kubectl get` above)
+
+#### Container Storages
+
+The `Storages` defined in the profile allow NNF filesystems to be made available inside of the
+container. These storages need to be referenced in the container workflow unless they are marked as
+optional.
+
+There are three types of storages available to containers:
+
+- local non-persistent storage (created via `#DW_JOB` directives)
+- persistent storage (created via `#DW_PERSISTENT` directives)
+- global lustre storage (defined by `LustreFilesystems`)
+
+For local and persistent storage, only GFS2 and Lustre filesystems are supported. Raw and XFS
+filesystems cannot be mounted more than once, so they cannot be mounted inside of a container while
+also being mounted on the NNF node itself.
+
+For each storage in the profile, the name must follow these patterns (depending on the storage type):
+
+- `DW_JOB_<storage_name>`
+- `DW_PERSISTENT_<storage_name>`
+- `DW_GLOBAL_<storage_name>`
+
+`<storage_name>` is provided by the user and needs to be a name compatible with Linux environment
+variables (so underscores must be used, not dashes), since the storage mount directories are
+provided to the container via environment variables.
+
+This storage name is used in container workflow directives to reference the NNF storage name that
+defines the filesystem. More on that in [Creating a Container
+Workflow](#creating-a-container-workflow).
+
+Storages may deemed be `optional` in a profile. If a storage is not option, the storage name
+must be set the name of an NNF filesystem name in the container workflow.
+
+For global lustre, there is an additional field for `pvcMode`, which must match the mode that is
+configured in the `LustreFilesystem` resource that represents the global lustre filesystem. This
+defaults to `ReadWriteMany`.
+
+Example:
 
 ```yaml
-kind: NnfContainerProfile
-metadata:
-  name: sample-nnfcontainerprofile
-  namespace: nnf-system
-data:
-  # Request the number of ports to open on the targeted rabbits. These ports are accessible outside
-  # of the k8s cluster.  The requested ports are made available as environment variables inside the
-  # container and in the DWS workflow (NNF_CONTAINER_PORTS).
-  numPorts: 1
+  storages:
+  - name: DW_JOB_foo_local_storage
+    optional: false
+  - name: DW_PERSISTENT_foo_persistent_storage
+    optional: true
+  - name: DW_GLOBAL_foo_global_lustre
+    optional: true
+    pvcMode: ReadWriteMany
 ```
 
-The allocated port numbers are made available via the [`NNF_CONTAINER_PORTS`](#nnf_container_ports) environment variable.
+#### Container Spec
 
-The workflow requests this number of ports from the `NnfPortManager`, which is responsible for managing the ports allocated to container workflows. This resource can be inspected to see which ports are allocated.
+As mentioned earlier, container workflows can be categorized into two types: MPI and Non-MPI. It's
+essential to choose and define only one of these types within the container profile. Regardless of
+the type chosen, the data structure that implements the specification is equipped with two
+"standard" resources that are distinct from NNF custom resources.
 
-These ports are opened on the NNF Nodes that are targeted by the container workflow. When a port is assigned, it becomes "reserved" for all NNF Nodes in the system. This reservation occurs even if the port is unused by the NNF Nodes not involved in the specific container workflow. To clarify, if port 4001 is employed by a container workflow that targets 6 out of 10 NNF Nodes within the system, any subsequent workflow cannot utilize port 4001 on the remaining 4 NNF Nodes.
+For Non-MPI containers, the specification utilizes the `spec` resource. This is the standard
+Kubernetes
+[`PodSpec`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
+that outlines the desired configuration for the pod.
+
+For MPI containers, `mpiSpec` is used. This custom resource, available through
+[`MPIJobSpec`]
+from `mpi-operator`, serves as a facilitator for executing MPI applications across worker
+containers. This resource can be likened to a wrapper around a `PodSpec`, but users
+need to define a `PodSpec` for both Launcher and Worker containers.
+
+See the [`MPIJobSpec`
+definition](https://github.com/kubeflow/mpi-operator/blob/v0.4.0/pkg/apis/kubeflow/v2beta1/types.go#L137)
+for more details on what can be configured for an MPI application.
+
+It's important to bear in mind that the NNF Software is designed to override specific values within
+the `MPIJobSpec` for ensuring the desired behavior in line with NNF software requirements. To
+prevent complications, it's advisable not to delve too deeply into the specification. A few
+illustrative examples of fields that have been preconfigured include:
+
+- Replicas
+- RunPolicy.BackoffLimit
+- Worker/Launcher.RestartPolicy
+- SSHAuthMountPath
+
+By keeping these considerations in mind and refraining from extensive alterations to the
+specification, you can ensure a smoother integration with the NNF Software and mitigate any
+potential issues that may arise.
+
+Please see the Sample and Examples listed above for more detail on container Specs.
+
+#### Container Ports
+
+Container Profiles allow for ports to be reserved for a container workflow. `numPorts` can be used
+to specify the number of ports needed for a container workflow. The ports are opened on each
+targeted NNF node and are accessible outside of the cluster. Users must know how to contact the
+specific NNF node. It is recommend that DNS entries are made for this purpose.
+
+In the workflow, the allocated port numbers are made available via the
+[`NNF_CONTAINER_PORTS`](#nnf_container_ports) environment variable.
+
+The workflow requests this number of ports from the `NnfPortManager`, which is responsible for
+managing the ports allocated to container workflows. This resource can be inspected to see which
+ports are allocated.
+
+Once a port is assigned to a workflow, that port number becomes unavailable for use by any other
+workflow until it is released.
 
 !!! note
 
-    The `SystemConfiguration` must be configured to allow for a range of ports, otherwise container workflows will fail in the `Setup` state due to insufficient resources. See [SystemConfiguration Setup](#systemconfiguration-setup).
+    The `SystemConfiguration` must be configured to allow for a range of ports, otherwise container
+    workflows will fail in the `Setup` state due to insufficient resources. See [SystemConfiguration
+    Setup](#systemconfiguration-setup).
 
 ### SystemConfiguration Setup
 
-In order for container workflows to request ports from the `NnfPortManager`, the `SystemConfiguration` must be configured for a range of ports:
+In order for container workflows to request ports from the `NnfPortManager`, the
+`SystemConfiguration` must be configured for a range of ports:
 
 ```yaml
 kind: SystemConfiguration
 metadata:
   name: default
-  namspace: default
+  namespace: default
 spec:
   # Ports is the list of ports available for communication between nodes in the
   # system. Valid values are single integers, or a range of values of the form
@@ -108,67 +193,222 @@ spec:
 
 `ports` is empty by default, and **must** be set by an administrator.
 
-Multiple port ranges can be specified in this list, as well as single integers. This must be a safe port range that does not interfere with the ephemeral port range of the Linux kernel. The range should also account for the estimated number of simultaneous users that are running container workflows.
+Multiple port ranges can be specified in this list, as well as single integers. This must be a safe
+port range that does not interfere with the ephemeral port range of the Linux kernel. The range
+should also account for the estimated number of simultaneous users that are running container
+workflows.
 
-Once a container workflow is done, the port is released and the `NnfPortManager` will not allow reuse of the port until the amount of time specified by `portsCooldownInSeconds` has elapsed. Then the port can be reused by another container workflow.
+Once a container workflow is done, the port is released and the `NnfPortManager` will not allow
+reuse of the port until the amount of time specified by `portsCooldownInSeconds` has elapsed. Then
+the port can be reused by another container workflow.
 
-## Custom NnfContainerProfile
+#### Restricting To User ID or Group ID
 
-The author of a containerized application will work with the administrator to
-define a pod specification template for the container and to create an
-appropriate NnfContainerProfile resource for the container.  The image and tag
-for the user's container will be specified in the profile.
+New NnfContainerProfile resources may be restricted to a specific user ID or group ID . When a
+`data.userID` or `data.groupID` is specified in the profile, only those Workflow resources having a
+matching user ID or group ID will be allowed to use that profile . If the profile specifies both of
+these IDs, then the Workflow resource must match both of them.
 
-New NnfContainerProfile resources may be created by copying one of the provided
-example profiles from the `nnf-system` namespace.  The examples may be found by listing them with `kubectl`:
+## Creating a Container Workflow
 
-```console
-kubectl get nnfcontainerprofiles -n nnf-system
-```
-
-### Workflow Job Specification
-
-The user's workflow will specify the name of the NnfContainerProfile in a DW
-directive.  If the custom profile is named `red-rock-slushy` then it will be
-specified in the "#DW container" directive with the "profile" parameter.
+The user's workflow will specify the name of the `NnfContainerProfile` in a DW directive. If the
+custom profile is named `red-rock-slushy` then it will be specified in the `#DW container` directive
+with the `profile` parameter.
 
 ```bash
 #DW container profile=red-rock-slushy  [...]
 ```
 
-### Restricting To User ID or Group ID
+Furthermore, to set the container storages for the workflow, storage parameters must also be
+supplied in the workflow. This is done using the `<storage_name>` (see [Container
+Storages](#container-storages)) and setting it to the name of a storage directive that defines an
+NNF filesystem. That storage directive must already exist as part of another workflow (e.g.
+persistent storage) or it can be supplied in the same workflow as the container. For global lustre,
+the `LustreFilesystem` must exist that represents the global lustre filesystem.
 
-New NnfContainerProfile resources may be restricted to a specific user ID
-or group ID.  When a `data.userID` or `data.groupID` is specified in the profile, only
-those Workflow resources having a matching user ID or group ID will be allowed to
-use that profile.  If the profile specifies both of these IDs, then the Workflow
-resource must match both of them.
+In this example, we're creating a GFS2 filesystem to accompany the container directive. We're using
+the `red-rock-slush` profile which contains a non-optional storage called `DW_JOB_local_storage`:
 
-## Using a Private Container Repository
+```yaml
+kind: NnfContainerProfile
+metadata:
+  name: red-rock-slushy
+data:
+  storages:
+  - name: DW_JOB_local_storage
+    optional: false
+  template:
+    mpiSpec:
+      ...
+```
 
-The user's containerized application may be placed in a private repository.  In
+The resulting container directive looks like this:
+
+```bash
+#DW jobdw name=my-gfs2 type=gfs2 capacity=100GB"
+#DW container name=my-container profile=red-rock-slushy DW_JOB_local_storage=my-gfs2
+```
+
+Once the workflow progresses, this will create a 100GB GFS2 filesystem that is then mounted into the
+container upon creation. An environment variable called `DW_JOB_local_storage` is made available
+inside of the container and provides the path to the mounted NNF GFS2 filesystem. An application
+running inside of the container can then use this variable to get to the filesystem mount directory.
+See [here](#container-environment-variables).
+
+Multiple storages can be defined in the container directives. Only one container directive is
+allowed per worfklow.
+
+## Running a Container Workflow
+
+TODO: Once the container exit strategy is complete, come back to this section to detail:
+
+- PreRun Behavior
+- PostRun Behavior
+- Teardown
+
+This will mostly be a from a WLM/DWS Workflow integration perspective, but will touch on the lower
+level workings.
+
+## Putting it All Together
+
+See the [NNF Container Example](https://github.com/NearNodeFlash/nnf-container-example) for a
+working example of how to run a simple MPI application inside of an NNF User Container and run it
+through a Container Workflow.
+
+## Reference
+
+### Environment Variables
+
+Two sets of environment variables are available with container workflows: Container and Compute
+Node. The former are the variables that are available inside the user containers. The latter are the
+variables that are provided back to the DWS workflow, which in turn are collected by the WLM and
+provided to compute nodes. See the WLM documentation for more details.
+
+#### Container Environment Variables
+
+These variables are provided for use inside the container. They can be used as part of the
+container command in the NNF Container Profile or within the container itself.
+
+##### Storages
+
+Each storage defined by a container profile and used in a container workflow results in a
+corresponding environment variable. This variable is used to hold the mount directory of the
+filesystem.
+
+##### Hostnames and Domains
+
+Containers can contact one another via Kubernetes cluster networking. This functionality is provided
+by DNS. Environment variables are provided that allow a user to be able to piece together the FQDN
+so that the other containers can be contacted.
+
+This example demonstrates an MPI container workflow, with two worker pods. Two worker pods means two
+pods/containers running on two NNF nodes.
+
+##### Ports
+
+See the `NNF_CONTAINER_PORTS`[](#nnf_container_ports) section under [Compute Node Environment
+Variables](#compute-node-environment-variables).
+
+```console
+mpiuser@my-container-workflow-launcher:~$ env | grep NNF
+NNF_CONTAINER_HOSTNAMES=my-container-workflow-launcher my-container-workflow-worker-0 my-container-workflow-worker-1
+NNF_CONTAINER_DOMAIN=default.svc.cluster.local
+NNF_CONTAINER_SUBDOMAIN=my-container-workflow-worker
+```
+
+The container FQDN consists of the following: `<HOSTNAME>.<SUBDOMAIN>.<DOMAIN>`. To contact the
+other worker container from worker 0,
+`my-container-workflow-worker-1.my-container-workflow-worker.default.svc.cluster.local` would be
+used.
+
+For MPI-based containers, an alternate way to retrieve this information is to look at the default
+`hostfile`, provided by `mpi-operator`. This file lists out all the worker nodes' FQDNs:
+
+```console
+mpiuser@my-container-workflow-launcher:~$ cat /etc/mpi/hostfile
+my-container-workflow-worker-0.my-container-workflow-worker.default.svc slots=1
+my-container-workflow-worker-1.my-container-workflow-worker.default.svc slots=1
+```
+
+#### Compute Node Environment Variables
+
+These environment variables are provided to the compute node via the WLM by way of the DWS Workflow.
+Note that these environment variables are consistent across all the compute nodes for a given
+workflow.
+
+!!! Note
+
+    It's important to note that the variables presented here pertain exclusively to User
+    Container-related variables. This list does not encompass the entirety of NNF environment
+    variables accessible to the compute node through the Workload Manager (WLM)
+
+#### `NNF_CONTAINER_PORTS`
+
+If the NNF Container Profile requests container ports, then this environment variable provides the
+allocated ports for the container. This is a comma separated list of ports if multiple ports are
+requested.
+
+This allows an application on the compute node to contact the user container running on its local
+NNF node via these port numbers. The compute node must have proper routing to the NNF Node and needs
+a generic way of contacting the NNF node. It is suggested than a DNS entry is provided via
+`/etc/hosts`, or similar.
+
+For cases where one port is requested, the following can be used to contact the user container
+running on the NNF node (assuming a DNS entry for `local-rabbit` is provided via `/etc/hosts`).
+
+```console
+local-rabbit:$(NNF_CONTAINER_PORTS)
+```
+
+### Creating Images
+
+For details, refer to the [NNF Container Example
+Readme](https://github.com/NearNodeFlash/nnf-container-example#making-a-container-image). However,
+in broad terms, an image that is capable of supporting MPI necessitates the following components:
+
+- User Application: Your specific application
+- Open MPI: Incorporate Open MPI to facilitate MPI operations
+- SSH Server: Including an SSH server to enable communication
+- nslookup: To validate Launcher/Worker container communication over the network
+
+By ensuring the presence of these components, users can create an image that supports MPI operations
+on the NNF platform.
+
+The [nnf-mfu image](https://github.com/NearNodeFlash/nnf-mfu) serves as a suitable base image,
+encompassing all the essential components required for this purpose.
+
+### Using a Private Container Repository
+
+The user's containerized application may be placed in a private repository . In
 this case, the user must define an access token to be used with that repository,
 and that token must be made available to the Rabbit's Kubernetes environment
 so that it can pull that container from the private repository.
 
-See [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) in the Kubernetes documentation
-for more information.
+See [Pull an Image from a Private
+Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) in
+the Kubernetes documentation for more information.
 
-### About the Example
+#### About the Example
 
 Each container registry will have its own way of letting its users create tokens to
-be used with their repositories.  Docker Hub will be used for the private repository in this example, and the user's account on Docker Hub will be "dean".
+be used with their repositories . Docker Hub will be used for the private repository in this
+example, and the user's account on Docker Hub will be "dean".
 
-### Preparing the Private Repository
+#### Preparing the Private Repository
 
-The user's application container is named "red-rock-slushy".  To store this container
-on Docker Hub the user must log into docker.com with their browser and click the "Create repository" button to create a repository named "red-rock-slushy", and the user must check the box that marks the repository as private.  The repository's name will be displayed as "dean/red-rock-slushy" with a lock icon to show that it is private.
+The user's application container is named "red-rock-slushy" . To store this container on Docker Hub
+the user must log into docker.com with their browser and click the "Create repository" button to
+create a repository named "red-rock-slushy", and the user must check the box that marks the
+repository as private . The repository's name will be displayed as "dean/red-rock-slushy" with a
+lock icon to show that it is private.
 
-### Create and Push a Container
+#### Create and Push a Container
 
-The user will create their container image in the usual ways, naming it for their private repository and tagging it according to its release.
+The user will create their container image in the usual ways, naming it for their private repository
+and tagging it according to its release.
 
-Prior to pushing images to the repository, the user must complete a one-time login to the Docker registry using the docker command-line tool.
+Prior to pushing images to the repository, the user must complete a one-time login to the Docker
+registry using the docker command-line tool.
 
 ```console
 docker login -u dean
@@ -180,13 +420,14 @@ After completing the login, the user may then push their images to the repositor
 docker push dean/red-rock-slushy:v1.0
 ```
 
-### Generate a Read-Only Token
+#### Generate a Read-Only Token
 
 A read-only token must be generated to allow Kubernetes to pull that container
-image from the private repository, because Kubernetes will not be running as
-that user.  **This token must be given to the administrator, who will use it to create a Kubernetes secret.**
+image from the private repository, because Kubernetes will not be running as that user . **This
+token must be given to the administrator, who will use it to create a Kubernetes secret.**
 
-To log in and generate a read-only token to share with the administrator, the user must follow these steps:
+To log in and generate a read-only token to share with the administrator, the user must follow these
+steps:
 
 - Visit docker.com and log in using their browser.
 - Click on the username in the upper right corner.
@@ -194,13 +435,12 @@ To log in and generate a read-only token to share with the administrator, the us
 - Click the "New Access Token" button to create a read-only token.
 - Keep a copy of the generated token to share with the administrator.
 
-### Store the Read-Only Token as a Kubernetes Secret
+#### Store the Read-Only Token as a Kubernetes Secret
 
-The adminstrator must store the user's read-only token as a kubernetes secret.  The
-secret must be placed in the `default` namespace, which is the same namespace
-where the user containers will be run.  The secret must include the user's Docker
-Hub username and the email address they have associated with that username.  In
-this case, the secret will be named `readonly-red-rock-slushy`.
+The administrator must store the user's read-only token as a kubernetes secret . The secret must be
+placed in the `default` namespace, which is the same namespace where the user containers will be
+run . The secret must include the user's Docker Hub username and the email address they have
+associated with that username . In this case, the secret will be named `readonly-red-rock-slushy`.
 
 ```console
 USER_TOKEN=users-token-text
@@ -210,14 +450,13 @@ SECRET_NAME=readonly-red-rock-slushy
 kubectl create secret docker-registry $SECRET_NAME -n default --docker-server="https://index.docker.io/v1/" --docker-username=$USER_NAME --docker-password=$USER_TOKEN --docker-email=$USER_EMAIL
 ```
 
-### Add the Secret to the NnfContainerProfile
+#### Add the Secret to the NnfContainerProfile
 
-The administrator must add an `imagePullSecrets` list to the NnfContainerProfile
-resource that was created for this user's containerized application.
+The administrator must add an `imagePullSecrets` list to the NnfContainerProfile resource that was
+created for this user's containerized application.
 
-The following profile shows the placement of the `readonly-red-rock-slushy` secret
-which was created in the previous step, and points to the user's
-`dean/red-rock-slushy:v1.0` container.
+The following profile shows the placement of the `readonly-red-rock-slushy` secret which was created
+in the previous step, and points to the user's `dean/red-rock-slushy:v1.0` container.
 
 ```yaml
 apiVersion: nnf.cray.hpe.com/v1alpha1
@@ -243,19 +482,19 @@ data:
     optional: true
 ```
 
-Now any user can select this profile in their Workflow by specifying it in a
-`#DW container` directive.
+Now any user can select this profile in their Workflow by specifying it in a `#DW container`
+directive.
 
 ```bash
 #DW container profile=red-rock-slushy  [...]
 ```
 
-### Using a Private Container Repository for MPI Application Containers
+#### Using a Private Container Repository for MPI Application Containers
 
-If our user's containerized application instead contains an MPI application,
-because perhaps it's a private copy of [nnf-mfu](https://github.com/NearNodeFlash/nnf-mfu),
-then the administrator would insert two `imagePullSecrets` lists into the
-`mpiSpec` of the NnfContainerProfile for the MPI launcher and the MPI worker.
+If our user's containerized application instead contains an MPI application, because perhaps it's a
+private copy of [nnf-mfu](https://github.com/NearNodeFlash/nnf-mfu), then the administrator would
+insert two `imagePullSecrets` lists into the `mpiSpec` of the NnfContainerProfile for the MPI
+launcher and the MPI worker.
 
 ```yaml
 apiVersion: nnf.cray.hpe.com/v1alpha1
@@ -302,8 +541,8 @@ data:
     optional: true
 ```
 
-Now any user can select this profile in their Workflow by specifying it in a
-`#DW container` directive.
+Now any user can select this profile in their Workflow by specifying it in a `#DW container`
+directive.
 
 ```bash
 #DW container profile=mpi-red-rock-slushy  [...]


### PR DESCRIPTION
Filled in most of the gaps and restructured the guide to walk a user through the concepts of creating profiles and a container workflow.

This does not touch on much of anything once the container is up and running. That will come later once the Container Exit Strategy has been revamped.