### PR TITLE
Updates for NNF dependencies

### DIFF
--- a/docs/guides/initial-setup/readme.md
+++ b/docs/guides/initial-setup/readme.md
@@ -52,7 +52,7 @@ Installation of Kubernetes (k8s) nodes proceeds by installing k8s components ont
 Webhooks require the Jetstack `cert-manager`. Installation is shown below.
 
 ```bash
-export certver="v1.7.0"
+export certver="v1.11.1"
 # Required for webhooks
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/"$certver"/cert-manager.yaml
 ```
@@ -63,7 +63,6 @@ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/"$ce
 | :------------------------------| :-------------------- |
 | Generic Kubernetes Worker Node | cray.nnf.manager=true |
 | Rabbit Node                    | cray.nnf.node=true    |
-|                                | cray.nnf.x-name=$NODE |
 
 ### Kubernetes Node Taints
 
@@ -71,7 +70,7 @@ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/"$ce
 | :------------------------------| :---------------------------- |
 | Rabbit Node                    | cray.nnf.node=true:NoSchedule |
 
-See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). The [NearNodeFlash/nnf-deploy/init.sh script](https://github.com/NearNodeFlash/nnf-deploy/blob/master/init.sh) provides examples of labeling and tainting k8s nodes for use with Rabbit.
+See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). The [nnf-deploy init](https://github.com/NearNodeFlash/nnf-deploy) command provides examples of labeling and tainting k8s nodes for use with Rabbit.
 
 ## Rabbit System Configuration
 

--- a/docs/guides/initial-setup/readme.md
+++ b/docs/guides/initial-setup/readme.md
@@ -70,7 +70,7 @@ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/"$ce
 | :------------------------------| :---------------------------- |
 | Rabbit Node                    | cray.nnf.node=true:NoSchedule |
 
-See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). The [nnf-deploy init](https://github.com/NearNodeFlash/nnf-deploy) command provides examples of labeling and tainting k8s nodes for use with Rabbit.
+See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). The [`nnf-deploy init`](https://github.com/NearNodeFlash/nnf-deploy) command provides examples of labeling and tainting k8s nodes for use with Rabbit.
 
 ## Rabbit System Configuration
 


### PR DESCRIPTION
Update the cert-manager version.

Remove the cray.nnf.x-name node label, which we've never used.

Refer to the `nnf-deploy init` command for taints and labels, rather then the obsolete init.sh script.