### PR TITLE
Remove "operator" from service account names and namespaces

### DIFF
--- a/docs/guides/compute-daemons/readme.md
+++ b/docs/guides/compute-daemons/readme.md
@@ -30,7 +30,7 @@ NNF software defines a Kubernetes Service Account for granting communication pri
 
 | Compute Daemon | Service Account | Namespace |
 | -------------- | --------------- | --------- |
-| Client Mount   | dws-operator-controller-manager | dws-operator-system |
+| Client Mount   | dws-controller-manager | dws-system |
 | Data Movement  | nnf-dm-controller-manager | nnf-dm-system |
 
 ```bash


### PR DESCRIPTION
The "operator" word was removed in DWS v0.0.13 as part of the move from HewlettPackard/dws to DataWorkflowServices/dws.