### PR TITLE
Added nnf-dm submodule to pull in auto-generated Copy Offload API

### DIFF
--- a/.github/workflows/publish-main.yaml
+++ b/.github/workflows/publish-main.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          submodules: 'true'
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          submodules: 'true'
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/nnf-dm"]
+	path = external/nnf-dm
+	url = git@github.com:NearNodeFlash/nnf-dm.git

--- a/docs/guides/data-movement/copy-offload-api.html
+++ b/docs/guides/data-movement/copy-offload-api.html
@@ -1,0 +1,1 @@
+../../../external/nnf-dm/daemons/compute/copy-offload-api.html

--- a/docs/guides/data-movement/readme.md
+++ b/docs/guides/data-movement/readme.md
@@ -87,5 +87,5 @@ The `CreateRequest` API call that is used to create Data Movement with the Copy 
 options to allow a user to specify some options for that particular Data Movement. These settings
 are on a per-request basis.
 
-See the [CreateRequest API](https://github.com/NearNodeFlash/nnf-dm/blob/master/daemons/compute/Readme.md#create-request)
+See the [DataMovementCreateRequest API](copy-offload-api.html#datamovement.DataMovementCreateRequest)
 definition for what can be configured.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -12,6 +12,7 @@
 
 * [Storage Profiles](storage-profiles/readme.md)
 * [Data Movement Configuration](data-movement/readme.md)
+* [Copy Offload API](data-movement/copy-offload-api.html)
 * [Lustre External MGT](external-mgs/readme.md)
 
 ## NNF User Containers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,30 +1,31 @@
 site_name: NNF
-site_description: "Near Node Flash"
+site_description: 'Near Node Flash'
 docs_dir: docs/
-repo_name: "NearNodeFlash/NearNodeFlash.github.io"
+repo_name: 'NearNodeFlash/NearNodeFlash.github.io'
 repo_url: https://github.com/NearNodeFlash/NearNodeFlash.github.io
-copyright: "&copy; Copyright 2023 Hewlett Packard Enterprise Development LP"
+copyright: '&copy; Copyright 2023 Hewlett Packard Enterprise Development LP'
 nav:
   - Home: index.md
-  - "User Guides":
+  - 'User Guides':
       - guides/index.md
-      - "Initial Setup": "guides/initial-setup/readme.md"
-      - "Compute Daemons": "guides/compute-daemons/readme.md"
-      - "Data Movement": "guides/data-movement/readme.md"
-      - "Firmware Upgrade": "guides/firmware-upgrade/readme.md"
-      - "High Availability Cluster": "guides/ha-cluster/readme.md"
-      - "RBAC for Users": "guides/rbac-for-users/readme.md"
-      - "Storage Profiles": "guides/storage-profiles/readme.md"
-      - "User Containers": "guides/user-containers/readme.md"
-      - "Lustre External MGT": "guides/external-mgs/readme.md"
-  - "RFCs":
+      - 'Initial Setup': 'guides/initial-setup/readme.md'
+      - 'Compute Daemons': 'guides/compute-daemons/readme.md'
+      - 'Data Movement': 'guides/data-movement/readme.md'
+      - 'Copy Offload API': 'guides/data-movement/copy-offload-api.html'
+      - 'Firmware Upgrade': 'guides/firmware-upgrade/readme.md'
+      - 'High Availability Cluster': 'guides/ha-cluster/readme.md'
+      - 'RBAC for Users': 'guides/rbac-for-users/readme.md'
+      - 'Storage Profiles': 'guides/storage-profiles/readme.md'
+      - 'User Containers': 'guides/user-containers/readme.md'
+      - 'Lustre External MGT': 'guides/external-mgs/readme.md'
+  - 'RFCs':
       - rfcs/index.md
-      - "Rabbit Request For Comment Process": "rfcs/0001/readme.md"
-      - "Rabbit Storage For Containerized Applications": "rfcs/0002/readme.md"
-  - "Repo Admin Guides":
-      - "Releasing NNF Software": "repo-guides/release-nnf-sw/readme.md"
+      - 'Rabbit Request For Comment Process': 'rfcs/0001/readme.md'
+      - 'Rabbit Storage For Containerized Applications': 'rfcs/0002/readme.md'
+  - 'Repo Admin Guides':
+      - 'Releasing NNF Software': 'repo-guides/release-nnf-sw/readme.md'
 theme:
-  name: "material"
+  name: 'material'
   custom_dir: overrides
   features:
     - content.code.copy


### PR DESCRIPTION
The Copy Offload API documentation is auto-generated using a gRPC plugin that produces HTML output. This document resides in the `nnf-dm` repository.

This adds a submodule for `nnf-dm` and a symbolic link to the auto-generated html. This allows the HTML to be displayed directly in the documentation on GitHub pages. Links to the HTML have been added.

The symbolic link should provide seamless support for versioning.