### PR TITLE
Undo the create_release job.

### DIFF
--- a/.github/workflows/publish-main.yaml
+++ b/.github/workflows/publish-main.yaml
@@ -33,22 +33,3 @@ jobs:
         run: |
           mike deploy --push dev
 
-  create_release:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-tags: true
-        fetch-depth: 0
-    - name: Repair tag
-      run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
-    - name: Verify that the tag is annotated
-      run: if test x$(git for-each-ref ${{ github.ref }} | awk '{print $2}') = xtag; then /bin/true; else echo "\"${{ github.ref }}\" does not look like an annotated tag!"; /bin/false; fi
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        #prerelease: true
-        generate_release_notes: true


### PR DESCRIPTION
This job is not yet causing the `mike` tool to create a proper doc release.

The "create release" button in the GUI causes the `mike` tool in .github/workflows/release.yaml to properly create a new doc release in its dropdown when viewed via https://nearnodeflash.github.io.