### PR TITLE
rbac: fix typo in guide

### DIFF
--- a/docs/guides/rbac-for-users/readme.md
+++ b/docs/guides/rbac-for-users/readme.md
@@ -147,7 +147,7 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: workload-manager
+  name: dws-workload-manager
   apiGroup: rbac.authorization.k8s.io
 ```
 


### PR DESCRIPTION
Problem: there is a typo in the example ClusterRoleBinding given in the RBAC guide, so it cannot be used as provided.

Fix the typo.